### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc.9] - 2021-02-08
+
+### Fixed
+
+- Properly extract the `updatedAt` field from Contentful.
+
+### Added
+
+- Code blocks now have a copy to clipboard button.
+
+### Changed
+
+- Moved `<CodeBlock />` to its own component.
+- Reworked the way `<Code />` and `<CodeBlock />` components inherit styles when they're contained within another colorSchemed component, such as `Admonition />`.
+
 ## [1.0.0-rc.8] - 2021-02-02
 
 ### Fixed

--- a/components/codeBlock/codeBlock.tsx
+++ b/components/codeBlock/codeBlock.tsx
@@ -1,0 +1,89 @@
+import dynamic from 'next/dynamic';
+import {
+  Box,
+  Icon,
+  useClipboard,
+  IconButton,
+  useStyleConfig,
+  useBreakpointValue,
+} from '@chakra-ui/react';
+import { useColorValue } from '~/context';
+import { useCodeBlockStyle } from './useCodeBlockStyle';
+
+import type { ICodeBlock } from './types';
+
+const CopyIcon = dynamic<MeronexIcon>(() => import('@meronex/icons/bi').then(i => i.BiCopy));
+const CheckIcon = dynamic<MeronexIcon>(() => import('@meronex/icons/bi').then(i => i.BiCheck));
+
+export const CodeBlock: React.FC<ICodeBlock> = (props: ICodeBlock) => {
+  const { children, ...rest } = props;
+  const defaultScheme = useColorValue('gray', 'tertiary');
+  const size = useBreakpointValue({ base: 'md', lg: 'sm' });
+
+  let ctx = useCodeBlockStyle();
+
+  if (ctx === null) {
+    ctx = {
+      codeBlock: { colorScheme: defaultScheme },
+      copyButton: { colorScheme: defaultScheme, variant: 'ghost' },
+    };
+  }
+
+  const { bg, color } = useStyleConfig('Code', { colorScheme: ctx.codeBlock.colorScheme });
+
+  const btnSx = useStyleConfig('Button', {
+    colorScheme: ctx.copyButton.colorScheme,
+    variant: 'ghost',
+  });
+  const { hasCopied, onCopy } = useClipboard(children);
+
+  return (
+    <Box
+      p={3}
+      mt={5}
+      border="1px"
+      fontSize="sm"
+      pos="relative"
+      borderRadius="md"
+      borderColor="inherit"
+      sx={{ bg, color }}
+      {...rest}
+    >
+      <Box
+        as="pre"
+        fontFamily="mono"
+        whiteSpace="pre-wrap"
+        minHeight={btnSx.h as number}
+        css={{ '& > code': { background: 'unset', color: 'unset', padding: 0 } }}
+      >
+        {children}
+      </Box>
+      <IconButton
+        sx={btnSx}
+        m={2}
+        top={0}
+        right={0}
+        size={size}
+        pos="absolute"
+        aria-label="Copy to Clipboard"
+        icon={
+          <>
+            <Icon
+              as={CheckIcon}
+              transition="all 0.2s ease"
+              opacity={hasCopied ? 1 : 0}
+              pos={hasCopied ? undefined : 'absolute'}
+            />
+            <Icon
+              as={CopyIcon}
+              transition="all 0.2s ease"
+              opacity={hasCopied ? 0 : 1}
+              pos={hasCopied ? 'absolute' : undefined}
+            />
+          </>
+        }
+        onClick={onCopy}
+      />
+    </Box>
+  );
+};

--- a/components/codeBlock/codeBlock.tsx
+++ b/components/codeBlock/codeBlock.tsx
@@ -35,7 +35,15 @@ export const CodeBlock: React.FC<ICodeBlock> = (props: ICodeBlock) => {
     colorScheme: ctx.copyButton.colorScheme,
     variant: 'ghost',
   });
-  const { hasCopied, onCopy } = useClipboard(children);
+
+  let copyValue = '';
+  if (typeof children === 'string') {
+    copyValue = children;
+  } else {
+    copyValue = children.props.children;
+  }
+
+  const { hasCopied, onCopy } = useClipboard(copyValue);
 
   return (
     <Box

--- a/components/codeBlock/index.ts
+++ b/components/codeBlock/index.ts
@@ -1,0 +1,2 @@
+export * from './codeBlock';
+export * from './useCodeBlockStyle';

--- a/components/codeBlock/types.ts
+++ b/components/codeBlock/types.ts
@@ -1,0 +1,5 @@
+import type { BoxProps } from '@chakra-ui/react';
+
+export interface ICodeBlock extends BoxProps {
+  children: string;
+}

--- a/components/codeBlock/types.ts
+++ b/components/codeBlock/types.ts
@@ -1,5 +1,5 @@
 import type { BoxProps } from '@chakra-ui/react';
 
 export interface ICodeBlock extends BoxProps {
-  children: string;
+  children: string | JSX.Element;
 }

--- a/components/codeBlock/useCodeBlockStyle.ts
+++ b/components/codeBlock/useCodeBlockStyle.ts
@@ -1,0 +1,19 @@
+/**
+ * Used to override the colorScheme and/or variant for a Code or CodeBlock component if it's
+ * contained within another component with differing styles, such as the Admonition.
+ */
+import { createContext, useContext } from 'react';
+
+import type { CodeProps } from '@chakra-ui/react';
+
+interface TCodeBlockStyleCtx {
+  copyButton: CodeProps;
+  codeBlock: CodeProps;
+}
+
+const CodeBlockStyleCtx = createContext<TCodeBlockStyleCtx | null>(null);
+
+export const { Provider: CodeBlockStyleProvider } = CodeBlockStyleCtx;
+
+export const useCodeBlockStyle = (): TCodeBlockStyleCtx | null =>
+  useContext<TCodeBlockStyleCtx | null>(CodeBlockStyleCtx);

--- a/components/docs/ipRanges.tsx
+++ b/components/docs/ipRanges.tsx
@@ -30,17 +30,17 @@ export const IPRanges: React.FC = () => {
               <Heading as="h3" size="md">
                 IPv4 Ranges
               </Heading>
-              <CodeBlock>{data?.ipv4.join('\n')}</CodeBlock>
+              <CodeBlock>{data?.ipv4.join('\n') ?? ''}</CodeBlock>
             </Box>
             <Box>
               <Heading as="h3" size="md">
                 IPv6 Ranges
               </Heading>
-              <CodeBlock>{data?.ipv6.join('\n')}</CodeBlock>
+              <CodeBlock>{data?.ipv6.join('\n') ?? ''}</CodeBlock>
             </Box>
             <Box>
               <Heading as="h3" size="md">{`Domains & URLs`}</Heading>
-              <CodeBlock>{data?.urls.join('\n')}</CodeBlock>
+              <CodeBlock>{data?.urls.join('\n') ?? ''}</CodeBlock>
             </Box>
             <Box maxW={{ base: '100%', lg: '50%' }}>
               <Heading as="h3" size="md">

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,6 +4,7 @@ export * from './button';
 export * from './callToAction';
 export * from './card';
 export * from './carousel';
+export * from './codeBlock';
 export * from './contactForm';
 export * from './content';
 export * from './contentSection';

--- a/components/richText/Admonition.tsx
+++ b/components/richText/Admonition.tsx
@@ -1,14 +1,6 @@
 import dynamic from 'next/dynamic';
-import {
-  Box,
-  Heading,
-  chakra,
-  Icon,
-  HStack,
-  StylesProvider,
-  useMultiStyleConfig,
-  useToken,
-} from '@chakra-ui/react';
+import { Box, Heading, chakra, Icon, HStack, useToken } from '@chakra-ui/react';
+import { CodeBlockStyleProvider } from '~/components';
 import { useColorValue } from '~/context';
 import { useOpposingColor, useRender, useTitle } from '~/hooks';
 import { shouldForwardProp } from '~/util';
@@ -82,7 +74,7 @@ export const Admonition: React.FC<TAdmonition> = (props: TAdmonition) => {
     },
     {
       Note: 'secondary.500',
-      Information: 'tertiary.300',
+      Information: 'gray.800',
       Tip: 'primary.300',
       Warning: 'primary.300',
       Critical: 'primary.300',
@@ -106,10 +98,6 @@ export const Admonition: React.FC<TAdmonition> = (props: TAdmonition) => {
     },
   )[type];
 
-  const styles = useMultiStyleConfig('Code', {
-    colorScheme: codeColorScheme,
-  });
-
   const color = useOpposingColor(bg);
 
   return (
@@ -128,7 +116,14 @@ export const Admonition: React.FC<TAdmonition> = (props: TAdmonition) => {
           '& a': { '--link-color': useToken('colors', linkColor!) },
         }}
       >
-        <StylesProvider value={styles}>{renderedBody}</StylesProvider>
+        <CodeBlockStyleProvider
+          value={{
+            codeBlock: { colorScheme: codeColorScheme },
+            copyButton: { colorScheme: codeColorScheme, variant: 'ghost' },
+          }}
+        >
+          {renderedBody}
+        </CodeBlockStyleProvider>
       </Box>
     </AdmonitionContainer>
   );

--- a/components/richText/Markdown.tsx
+++ b/components/richText/Markdown.tsx
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic';
 import { Box } from '@chakra-ui/react';
-import { Link } from '~/components';
+import { Link, CodeBlock } from '~/components';
 import { useColorValue } from '~/context';
 import { H1, H2, H3, H4, H5, H6 } from './Headings';
-import { Code, BlockQuote, P, CodeBlock } from './Texts';
+import { Code, BlockQuote, P } from './Texts';
 import { Ul, Ol, Li } from './Lists';
 
 const MarkdownToJSX = dynamic(() => import('markdown-to-jsx'));

--- a/components/richText/Texts.tsx
+++ b/components/richText/Texts.tsx
@@ -1,14 +1,8 @@
-import {
-  Box,
-  Code as ChakraCode,
-  Text,
-  useStyles,
-  useStyleConfig,
-  useToken,
-} from '@chakra-ui/react';
+import { Box, Text, useToken, useStyleConfig, Code as ChakraCode } from '@chakra-ui/react';
+import { useCodeBlockStyle } from '~/components';
 import { useColorValue } from '~/context';
 
-import type { IBlockQuote, ICode, IParagraph, IInline, ICodeBlock } from './types';
+import type { IBlockQuote, ICode, IParagraph, IInline } from './types';
 
 export const P: React.FC<IParagraph> = (props: IParagraph) => (
   <Text my={8} css={{ '&:first-of-type': { marginTop: useToken('space', 2) } }} {...props} />
@@ -39,7 +33,12 @@ export const BlockQuote: React.FC<IBlockQuote> = (props: IBlockQuote) => {
 
 export const Code: React.FC<ICode> = (props: ICode) => {
   const scheme = useColorValue('gray', 'tertiary');
-  const sx = useStyles();
+
+  let ctx = useCodeBlockStyle();
+  if (ctx === null) {
+    ctx = { codeBlock: { colorScheme: scheme }, copyButton: {} };
+  }
+  const sx = useStyleConfig('Code', { colorScheme: ctx.codeBlock.colorScheme });
   return <ChakraCode fontSize="sm" colorScheme={scheme} px={1} sx={sx} {...props} />;
 };
 
@@ -49,28 +48,5 @@ export const Inline: React.FC<IInline> = (props: IInline) => {
     <Box as="span" key={node.data.target.sys.id} {...rest}>
       type: {node.nodeType} id: {node.data.target.sys.id}
     </Box>
-  );
-};
-
-export const CodeBlock: React.FC<ICodeBlock> = (props: ICodeBlock) => {
-  const colorScheme = useColorValue('gray', 'tertiary');
-  const { borderRadius, px, ...sx } = useStyles();
-  const { bg, color } = useStyleConfig('Code', { colorScheme });
-
-  return (
-    <Box
-      p={3}
-      mt={5}
-      as="pre"
-      border="1px"
-      rounded="md"
-      fontSize="sm"
-      fontFamily="mono"
-      borderColor="inherit"
-      whiteSpace="pre-wrap"
-      sx={{ bg, color, ...sx }}
-      css={{ '& > code': { background: 'unset', color: 'unset', padding: 0 } }}
-      {...props}
-    />
   );
 };

--- a/components/richText/types.ts
+++ b/components/richText/types.ts
@@ -84,8 +84,6 @@ export interface IMarkdown {
   children: string;
 }
 
-export interface ICodeBlock extends BoxProps {}
-
 export interface IAdmonitionIcon {
   type: TAdmonition['type'];
 }

--- a/hooks/useDate.ts
+++ b/hooks/useDate.ts
@@ -11,9 +11,12 @@ dayjs.extend(advFmt);
 dayjs.extend(timezone);
 
 export function useDate(
-  utcTime: string,
+  utcTime: string | null,
   options: UseDateOptions = { format: 'MMMM DD, YYYY HH:mm:ss z' },
 ): string {
+  if (utcTime === null) {
+    return 'Unknown';
+  }
   const parsed = dayjs(utcTime);
   let local = parsed;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellaraf/site",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "private": true,
   "dependencies": {
     "@chakra-ui/react": "^1.1.1",

--- a/pages/docs/[group]/[slug].tsx
+++ b/pages/docs/[group]/[slug].tsx
@@ -52,7 +52,6 @@ export const getStaticProps: GetStaticProps<IDocsArticlePage, UrlQuery> = async 
   try {
     const res = await getParsedContent<IDocsArticlePage['article']>('docsArticle', preview, {
       'fields.slug': slug,
-      select: 'sys.id,fields',
     });
     article = res[0];
   } catch (err) {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -5,3 +5,5 @@ type ReactRef<E extends HTMLElement = HTMLElement> = React.MutableRefObject<E>;
 type Animated<T> = Omit<T, 'transition'> & import('framer-motion').MotionProps;
 
 type MeronexIcon = import('@meronex/icons').IconBaseProps;
+
+interface Empty {} // eslint-disable-line

--- a/util/contentful/common.ts
+++ b/util/contentful/common.ts
@@ -43,13 +43,13 @@ export async function getContentType<T extends unknown>(
 /**
  * Query Contentful for a specific content_type
  */
-export async function getParsedContent<T extends unknown>(
+export async function getParsedContent<T extends Empty>(
   contentType: string,
   preview: boolean = false,
   query: Dict = {},
 ): Promise<T[]> {
   const queryParams = merge(
-    { content_type: contentType, include: 4, select: 'sys.id,fields' },
+    { content_type: contentType, include: 4, select: 'sys.id,sys.updatedAt,fields' },
     query,
   );
 
@@ -57,7 +57,10 @@ export async function getParsedContent<T extends unknown>(
     const thisClient = client(preview);
     const entries = await thisClient.getEntries<T>(queryParams);
     const parsed = await thisClient.parseEntries<T>(entries);
-    return parsed.items.map(i => i.fields);
+    return parsed.items.map(item => ({
+      ...item.fields,
+      updatedAt: item.sys.updatedAt ?? null,
+    }));
   } catch (err) {
     console.error(err);
     throw err;


### PR DESCRIPTION
## [1.0.0-rc.9] - 2021-02-08

### Fixed

- Properly extract the `updatedAt` field from Contentful.

### Added

- Code blocks now have a copy to clipboard button.

### Changed

- Moved `<CodeBlock />` to its own component.
- Reworked the way `<Code />` and `<CodeBlock />` components inherit styles when they're contained within another colorSchemed component, such as `Admonition />`.